### PR TITLE
refactor: DRY shared head content via head-common.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+assets/Team-profile-generator-demo-2021-01-29.mp4
+
+assets/Team-profile-generator-demo-2021-01-29.mp4
+
+assets/Team-profile-generator-demo-2021-01-29.mp4

--- a/contact.html
+++ b/contact.html
@@ -1,143 +1,159 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <title>Contact</title>
 
-	<head>
-		<script src="https://code.jquery.com/jquery-3.3.1.js"
-			integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-		<script>
-			$(function ()
-			{
-				$("#header").load("header.html");
-				$("#footer").load("footer.html");
-			});
-		</script>
-		<!--Title-->
-		<title>Contact</title>
-		<!--Favicon-->
-		<link rel="shortcut icon" type="image/png" href="favicon.png" />
-		<!--Encoding-->
-		<meta charset="UTF-8" />
-		<!--Metatext-->
-		<meta name="Portfolio" />
-		<!--SEO Keywords-->
-		<meta name="keywords"
-			content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, slate" />
-		<!--Author-->
-		<meta name="author" content="Melissa Kinsey" />
-		<!--Viewport Dimensions-->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!--Bootstrap Link-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
-		<!-- Google Fonts Link -->
-		<link href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-			rel="stylesheet" />
-		<!--CSS Link-->
-		<link rel="stylesheet" href="style.css" />
-		</head>
-		<body>		
-		<!--NAV HEADER-->
-		<div id="header"></div>
-		<!--BEGIN CONTAINER-1-->
-		<div class="container-1">
-			<div class="jumbotron">
-				<div class="container text-center">
-					<img src="assets/name-5.png" width="70%" />
-					<p id="jumbotron">
-						I'm a tenacious, results-driven leader with tons of tech writing and content development experience and at least a respectable level of technical expertise. At Amazon Devices & Services, I founded a thriving Slack channel, #grammar-medics, that's now grown to 4,000 members. I serve as a Document Bar Raiser team lead, handle all Alexa Music, Radio, and Podcasts tech docs, and develop AI and other courses for Alexa Learning Lab. <br>
-                        <br>
-                        In my free time, I'm (still) trying to learn German. Fahrvergnügen.
-					</p>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.js"
+      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+  <body>
+    <!--NAV HEADER-->
+    <div id="header"></div>
+    <!--BEGIN CONTAINER-1-->
+    <div class="container-1">
+      <div class="jumbotron">
+        <div class="container text-center">
+          <img src="assets/name-5.png" width="70%" />
+          <p id="jumbotron">
+            I'm a tenacious, results-driven leader with tons of tech writing and
+            content development experience and at least a respectable level of
+            technical expertise. At Amazon Devices & Services, I founded a
+            thriving Slack channel, #grammar-medics, that's now grown to 4,000
+            members. I serve as a Document Bar Raiser team lead, handle all
+            Alexa Music, Radio, and Podcasts tech docs, and develop AI and other
+            courses for Alexa Learning Lab. <br />
+            <br />
+            In my free time, I'm (still) trying to learn German. Fahrvergnügen.
+          </p>
 
-					<div class="col-sm-4">
-						<p style="font-size:1.25rem">
-							<a href="https://github.com/melissakinsey"><img src="assets/github-mark.png">
-								GitHub
-							</a>
-						</p>
-					</div>
-					<div class="col-sm-4">
-						<p style="font-size:1.25rem">
-							<a href="http://www.linkedin.com/in/melissajaynekinsey/"><img
-									src="assets/linkedin-icon.png">
-								LinkedIn
-							</a>
-						</p>
-					</div>
-					<div class="col-sm-4">
-						<p style="font-size:1.25rem">
-							<a href="assets/resume.pdf"><img src="assets/resume-icon.png">
-								Resume
-							</a>
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
+          <div class="col-sm-4">
+            <p style="font-size: 1.25rem">
+              <a href="https://github.com/melissakinsey"
+                ><img src="assets/github-mark.png" />
+                GitHub
+              </a>
+            </p>
+          </div>
+          <div class="col-sm-4">
+            <p style="font-size: 1.25rem">
+              <a href="http://www.linkedin.com/in/melissajaynekinsey/"
+                ><img src="assets/linkedin-icon.png" />
+                LinkedIn
+              </a>
+            </p>
+          </div>
+          <div class="col-sm-4">
+            <p style="font-size: 1.25rem">
+              <a href="assets/resume.pdf"
+                ><img src="assets/resume-icon.png" />
+                Resume
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
 
-		<div class="container-fluid bg-3 text-center">
-			<div class="row">
-				<div>
-					<h1 class="special">Contact Me</h1>
-				</div>
-				<div class="col-sm-3">
-					<div>
-					<img src="assets/profile-vertical.png" style="width: auto" class="shadow img-responsive"  id="melissa" alt="Melissa Kinsey" />
-					</div>
-					<div style="align-content: center"> 
-						<img src="assets/decorative-element.png"
-					id="decorative"
-					alt="decorative-element">
-				</div>
-			</div>
-				<div class="col-sm-6">
-					<form action="/action_page.php">
-						<span><label for="fname">First Name</label>
-							<input type="text" id="fname" name="firstname" /></span>
-						<span><label for="lname">Last Name</label>
-							<input type="text" id="lname" name="lastname" /></span>
-						<span><label for="country">Country</label>
-							<br>
-							<br>
-							<br><select id="country" name="country">
-								<option value="USA">USA</option>
-								<option value="Austria">Austria</option>
-								<option value="Bangladesh">Bangladesh</option>
-								<option value="Canada">Canada</option>
-								<option value="China">China</option>
-								<option value="Dominican Republic">
-									Dominican Republic
-								</option>
-								<option value="Germany">Germany</option>
-								<option value="India">India</option>
-								<option value="Iran">Iran</option>
-								<option value="Iraq">Iraq</option>
-								<option value="Ireland">Ireland</option>
-								<option value="Israel">Israel</option>
-								<option value="Pakistan">Pakistan</option>
-								<option value="Puerto Rico">Puerto Rico</option>
-								<option value="Soviet Union">
-									Soviet Union
-								</option>
-								<option value="Turkey">Turkey</option>
-								<option value="UAE">UAE</option>
-								<option value="UK">UK</option>
-								<option value="Ukraine">Ukraine</option>
-								<option value="Other">Other</option>
-							</select></span>
-						<span><label for="subject">Subject</label>
-							<br>
-							<br>
-							<br><input type="text" id="subject" name="subject" placeholder="Topic" /></span>
-						<span><label for="comments">Comment or question</label>
-							<input type="text" id="comments" name="comments"
-								placeholder="What can I do for you?" /></span>
-						<span><input type="submit" value="Submit" /></span>
-					</form>
-				</div>
-			</div>
-		</div>
-		<!--FOOTER-->
-		<div id="footer"></div>
-	</body>
-
+    <div class="container-fluid bg-3 text-center">
+      <div class="row">
+        <div>
+          <h1 class="special">Contact Me</h1>
+        </div>
+        <div class="col-sm-3">
+          <div>
+            <img
+              src="assets/profile-vertical.png"
+              style="width: auto"
+              class="shadow img-responsive"
+              id="melissa"
+              alt="Melissa Kinsey"
+            />
+          </div>
+          <div style="align-content: center">
+            <img
+              src="assets/decorative-element.png"
+              id="decorative"
+              alt="decorative-element"
+            />
+          </div>
+        </div>
+        <div class="col-sm-6">
+          <form action="/action_page.php">
+            <span
+              ><label for="fname">First Name</label>
+              <input type="text" id="fname" name="firstname"
+            /></span>
+            <span
+              ><label for="lname">Last Name</label>
+              <input type="text" id="lname" name="lastname"
+            /></span>
+            <span
+              ><label for="country">Country</label>
+              <br />
+              <br />
+              <br /><select id="country" name="country">
+                <option value="USA">USA</option>
+                <option value="Austria">Austria</option>
+                <option value="Bangladesh">Bangladesh</option>
+                <option value="Canada">Canada</option>
+                <option value="China">China</option>
+                <option value="Dominican Republic">Dominican Republic</option>
+                <option value="Germany">Germany</option>
+                <option value="India">India</option>
+                <option value="Iran">Iran</option>
+                <option value="Iraq">Iraq</option>
+                <option value="Ireland">Ireland</option>
+                <option value="Israel">Israel</option>
+                <option value="Pakistan">Pakistan</option>
+                <option value="Puerto Rico">Puerto Rico</option>
+                <option value="Soviet Union">Soviet Union</option>
+                <option value="Turkey">Turkey</option>
+                <option value="UAE">UAE</option>
+                <option value="UK">UK</option>
+                <option value="Ukraine">Ukraine</option>
+                <option value="Other">Other</option>
+              </select></span
+            >
+            <span
+              ><label for="subject">Subject</label>
+              <br />
+              <br />
+              <br /><input
+                type="text"
+                id="subject"
+                name="subject"
+                placeholder="Topic"
+            /></span>
+            <span
+              ><label for="comments">Comment or question</label>
+              <input
+                type="text"
+                id="comments"
+                name="comments"
+                placeholder="What can I do for you?"
+            /></span>
+            <span><input type="submit" value="Submit" /></span>
+          </form>
+        </div>
+      </div>
+    </div>
+    <!--FOOTER-->
+    <div id="footer"></div>
+  </body>
 </html>

--- a/github.html
+++ b/github.html
@@ -1,41 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <title>GitHub</title>
 
-	<head>
-		<script src="https://code.jquery.com/jquery-3.3.1.js"
-			integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-		<script>
-			$(function ()
-			{
-				$("#header").load("header.html");
-				$("#footer").load("footer.html");
-			});
-		</script>
-		<!--Title-->
-		<title>Boot Camp Projects</title>
-		<!--Favicon-->
-		<link rel="shortcut icon" type="image/png" href="favicon.png" />
-		<!--Encoding-->
-		<meta charset="UTF-8" />
-		<!--Metatext-->
-		<meta name="Boot Camp Projects" />
-		<!--SEO Keywords-->
-		<meta name="keywords"
-			content="portfolio, editing, technical-writing, documentation, programming, engineering, slate, github, boot camp" />
-		<!--Author-->
-		<meta name="author" content="Melissa Kinsey" />
-		<!--Viewport Dimensions-->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!--Bootstrap Link-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
-		<!-- Google Fonts Link -->
-		<link href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-			rel="stylesheet" />
-		<!--CSS Link-->
-		<link rel="stylesheet" href="style.css" />
-	</head>
-
-	<body>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.js"
+      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>	<body>
 		<!--NAV HEADER-->
 		<div id="header"></div>
 		<!--BEGIN CONTAINER-1-->

--- a/head-common.html
+++ b/head-common.html
@@ -1,0 +1,18 @@
+<link rel="shortcut icon" type="image/png" href="favicon.png" />
+<meta charset="UTF-8" />
+<meta name="description" content="Portfolio of Melissa Kinsey" />
+<meta
+  name="keywords"
+  content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, slate"
+/>
+<meta name="author" content="Melissa Kinsey" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link
+  rel="stylesheet"
+  href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="style.css" />

--- a/index.html
+++ b/index.html
@@ -1,46 +1,26 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <title>Portfolio</title>
+
     <script
       src="https://code.jquery.com/jquery-3.3.1.js"
       integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
       crossorigin="anonymous"
     ></script>
     <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
       $(function () {
         $("#header").load("header.html");
         $("#footer").load("footer.html");
       });
     </script>
-    <!--Title-->
-    <title>Portfolio</title>
-    <!--Favicon-->
-    <link rel="shortcut icon" type="image/png" href="favicon.png" />
-    <!--Encoding-->
-    <meta charset="UTF-8" />
-    <!--Metatext-->
-    <meta name="description" content="Portfolio of Melissa Kinsey" />
-    <!--SEO Keywords-->
-    <meta
-      name="keywords"
-      content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, slate"
-    />
-    <!--Author-->
-    <meta name="author" content="Melissa Kinsey" />
-    <!--Viewport Dimensions-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!--Bootstrap Link-->
-    <link
-      rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
-    />
-    <!-- Google Fonts Link -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <!--CSS Link-->
-    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <!--NAV HEADER-->

--- a/infographics.html
+++ b/infographics.html
@@ -1,136 +1,135 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <title>Infographics</title>
 
-	<head>
-		<script src="https://code.jquery.com/jquery-3.3.1.js"
-			integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-		<script>
-			$(function ()
-			{
-				$("#header").load("header.html");
-				$("#footer").load("footer.html");
-			});
-		</script>
-		<!--Title-->
-		<title>Infographics</title>
-		<!--Favicon-->
-		<link rel="shortcut icon" type="image/png" href="favicon.png" />
-		<!--Encoding-->
-		<meta charset="UTF-8" />
-		<!--Metatext-->
-		<meta name="Portfolio" />
-		<!--SEO Keywords-->
-		<meta name="keywords"
-			content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, communications, infographics, slate" />
-		<!--Author-->
-		<meta name="author" content="Melissa Kinsey" />
-		<!--Viewport Dimensions-->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!--Bootstrap Link-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
-		<!-- Google Fonts Link -->
-		<link href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-			rel="stylesheet" />
-		<!--CSS Link-->
-		<link rel="stylesheet" href="style.css" />
-	</head>
-
-	<body>
-		<!--NAV HEADER-->
-		<div id="header"></div>
-		<!--BEGIN CONTAINER-1-->
-		<div class="container-1">
-			<div class="jumbotron">
-				<div class="container text-center">
-					<img src="assets/name-5.png" width="70%" />
-					<p id="jumbotron">
-						No learner wants to be greeted by a wall of text when they launch a course. Colorful
-						illustrations make courses more inviting and convey complex concepts better than words alone.
-					</p>
-				</div>
-			</div>
-		</div>
-		<!--BEGIN CONTAINER-2-->
-		<div class="container-fluid bg-3 text-center">
-			<h1 class="special">Infographics</h1>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/AMZN-agent-workflow.png" style="width: auto; max-width: 800px"
-						alt="Infographic showing the agent SDK workflow" />
-				</div>
-				<div class="legend-bar">
-					Agent SDK workflow
-				</div>
-			</div>
-			<br>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/AMZN-dynamic-inputs.png" style="width: auto; max-width: 800px"
-						alt="Infographic showing dynamic inputs to an agent SDK" />
-				</div>
-				<br>
-				<div class="legend-bar">
-					Dynamic inputs to an SDK
-				</div>
-			</div>
-			<br>
-			<br>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/AMZN-request-handler.png" style="width: auto; max-width: 800px"
-						alt="Infographic showing how an agent receives and responds to requests" />
-				</div>
-				<br>
-				<br>
-				<div class="legend-bar">
-					Agent request handler
-				</div>
-			</div>
-			<br>
-			<br>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/CH-ordering-process.png" style="width: auto; max-width: 800px"
-						alt="Infographic showing the API ordering process" />
-				</div>
-				<br>
-				<br>
-				<div class="legend-bar">
-					API ordering process
-				</div>
-			</div>
-			<br>
-			<br>
-			<br>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/BCS-auth-before-after.png" style="width: auto; max-width: 800px"
-						alt="Infographic showing implicit and explicit authorization" />
-				</div>
-				<br>
-				<br>
-				<div class="legend-bar">
-					Implicit and explicit authorization (before, <i>left</i>; after, <i>right</i>)
-				</div>
-			</div>
-			<br>
-			<br>
-			<div class="row justify-items-center">
-				<div>
-					<img src="assets/CH-uml-offer-config.png" style="width: auto; max-width: 800px"
-						alt="Offerconfiguration in a payment API" />
-				</div>
-				<br>
-				<br>
-				<div class="legend-bar">
-					Offer configuration in a payment API (before, <i>left</i>; after, <i>right</i>)
-				</div>
-			</div>
-		</div>
-		<br>
-		<br>
-		<!--FOOTER-->
-		<div id="footer"></div>
-	</body>
-
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.js"
+      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+  <body>
+    <!--NAV HEADER-->
+    <div id="header"></div>
+    <!--BEGIN CONTAINER-1-->
+    <div class="container-1">
+      <div class="jumbotron">
+        <div class="container text-center">
+          <img src="assets/name-5.png" width="70%" />
+          <p id="jumbotron">
+            No learner wants to be greeted by a wall of text when they launch a
+            course. Colorful illustrations make courses more inviting and convey
+            complex concepts better than words alone.
+          </p>
+        </div>
+      </div>
+    </div>
+    <!--BEGIN CONTAINER-2-->
+    <div class="container-fluid bg-3 text-center">
+      <h1 class="special">Infographics</h1>
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/AMZN-agent-workflow.png"
+            style="width: auto; max-width: 800px"
+            alt="Infographic showing the agent SDK workflow"
+          />
+        </div>
+        <div class="legend-bar">Agent SDK workflow</div>
+      </div>
+      <br />
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/AMZN-dynamic-inputs.png"
+            style="width: auto; max-width: 800px"
+            alt="Infographic showing dynamic inputs to an agent SDK"
+          />
+        </div>
+        <br />
+        <div class="legend-bar">Dynamic inputs to an SDK</div>
+      </div>
+      <br />
+      <br />
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/AMZN-request-handler.png"
+            style="width: auto; max-width: 800px"
+            alt="Infographic showing how an agent receives and responds to requests"
+          />
+        </div>
+        <br />
+        <br />
+        <div class="legend-bar">Agent request handler</div>
+      </div>
+      <br />
+      <br />
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/CH-ordering-process.png"
+            style="width: auto; max-width: 800px"
+            alt="Infographic showing the API ordering process"
+          />
+        </div>
+        <br />
+        <br />
+        <div class="legend-bar">API ordering process</div>
+      </div>
+      <br />
+      <br />
+      <br />
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/BCS-auth-before-after.png"
+            style="width: auto; max-width: 800px"
+            alt="Infographic showing implicit and explicit authorization"
+          />
+        </div>
+        <br />
+        <br />
+        <div class="legend-bar">
+          Implicit and explicit authorization (before, <i>left</i>; after,
+          <i>right</i>)
+        </div>
+      </div>
+      <br />
+      <br />
+      <div class="row justify-items-center">
+        <div>
+          <img
+            src="assets/CH-uml-offer-config.png"
+            style="width: auto; max-width: 800px"
+            alt="Offerconfiguration in a payment API"
+          />
+        </div>
+        <br />
+        <br />
+        <div class="legend-bar">
+          Offer configuration in a payment API (before, <i>left</i>; after,
+          <i>right</i>)
+        </div>
+      </div>
+    </div>
+    <br />
+    <br />
+    <!--FOOTER-->
+    <div id="footer"></div>
+  </body>
 </html>

--- a/logos.html
+++ b/logos.html
@@ -1,153 +1,195 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <title>Logos</title>
 
-	<head>
-		<script src="https://code.jquery.com/jquery-3.3.1.js"
-			integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-		<script>
-			$(function ()
-			{
-				$("#header").load("header.html");
-				$("#footer").load("footer.html");
-			});
-		</script>
-		<!--Title-->
-		<title>Logo Design</title>
-		<!--Favicon-->
-		<link rel="shortcut icon" type="image/png" href="favicon.png" />
-		<!--Encoding-->
-		<meta charset="UTF-8" />
-		<!--Metatext-->
-		<meta name="Portfolio" />
-		<!--SEO Keywords-->
-		<meta name="keywords"
-			content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, slate" />
-		<!--Author-->
-		<meta name="author" content="Melissa Kinsey" />
-		<!--Viewport Dimensions-->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!--Bootstrap Link-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
-		<!-- Google Fonts Link -->
-		<link href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-			rel="stylesheet" />
-		<!--CSS Link-->
-		<link rel="stylesheet" href="style.css" />
-	</head>
-
-	<body>
-		<!--NAV HEADER-->
-		<div id="header"></div>
-		<!--BEGIN CONTAINER-1-->
-		<div class="container-1">
-			<div class="jumbotron">
-				<div class="container text-center">
-					<img src="assets/name-5.png" width="70%" />
-					<p id="jumbotron">
-						Writers are often called on to beautify UIs or do other design
-						work. I used Photoshop and Illustrator to create the logos
-						below.</p>
-				</div>
-			</div>
-		</div>
-		<div class="container-fluid bg-3 text-center">
-			<h1 class="special">Logo Design</h1>
-			<div class="row">
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/DFP-PIPELINE-LOGO.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for Pipeline engineering team" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/hydra-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for Hydra engineering team" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/android-team.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for Android engineering team" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/enterprise-team.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for enterprise engineering team" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/operations-group.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for engineering operations group" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/OL-team.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for engineering orchestration layer group" />
-					</p>
-				</div>
-			</div>
-			<div class="row">
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/tech-writing-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for technical writing team in the agriculture domain" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/workstream-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for workstream project" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/closer-look-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for 'Closer Look' feature." />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/op-ex-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for operational excellence team" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/sh-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for engineering Operations group" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/lexicon-project-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for engineering Operations group" />
-					</p>
-				</div>
-			</div>
-			<div class="row">
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/boot-camp-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for coding boot camp alumni network" />
-					</p>
-				</div>
-				<div class="col-sm-2">
-					<p>
-						<img src="logos/Alexa-Conversations-logo.png" class="shadow img-responsive" style="width: 200px"
-							alt="Logo for Amazon Alexa Conversations internal Confluence page." />
-					</p>
-					<br>
-					<br>
-					<br>
-				</div>
-			</div>
-		</div>
-		<!--FOOTER-->
-		<div id="footer"></div>
-	</body>
-
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.js"
+      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+  <body>
+    <!--NAV HEADER-->
+    <div id="header"></div>
+    <!--BEGIN CONTAINER-1-->
+    <div class="container-1">
+      <div class="jumbotron">
+        <div class="container text-center">
+          <img src="assets/name-5.png" width="70%" />
+          <p id="jumbotron">
+            Writers are often called on to beautify UIs or do other design work.
+            I used Photoshop and Illustrator to create the logos below.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="container-fluid bg-3 text-center">
+      <h1 class="special">Logo Design</h1>
+      <div class="row">
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/DFP-PIPELINE-LOGO.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for Pipeline engineering team"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/hydra-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for Hydra engineering team"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/android-team.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for Android engineering team"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/enterprise-team.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for enterprise engineering team"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/operations-group.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for engineering operations group"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/OL-team.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for engineering orchestration layer group"
+            />
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/tech-writing-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for technical writing team in the agriculture domain"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/workstream-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for workstream project"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/closer-look-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for 'Closer Look' feature."
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/op-ex-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for operational excellence team"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/sh-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for engineering Operations group"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/lexicon-project-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for engineering Operations group"
+            />
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/boot-camp-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for coding boot camp alumni network"
+            />
+          </p>
+        </div>
+        <div class="col-sm-2">
+          <p>
+            <img
+              src="logos/Alexa-Conversations-logo.png"
+              class="shadow img-responsive"
+              style="width: 200px"
+              alt="Logo for Amazon Alexa Conversations internal Confluence page."
+            />
+          </p>
+          <br />
+          <br />
+          <br />
+        </div>
+      </div>
+    </div>
+    <!--FOOTER-->
+    <div id="footer"></div>
+  </body>
 </html>

--- a/writing-samples.html
+++ b/writing-samples.html
@@ -1,211 +1,255 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <title>Writing Portfolio</title>
 
-	<head>
-		<script src="https://code.jquery.com/jquery-3.3.1.js"
-			integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-		<script>
-			$(function ()
-			{
-				$("#header").load("header.html");
-				$("#footer").load("footer.html");
-			});
-		</script>
-		<!--Title-->
-		<title>Writing Portfolio</title>
-		<!--Favicon-->
-		<link rel="shortcut icon" type="image/png" href="favicon.png" />
-		<!--Encoding-->
-		<meta charset="UTF-8" />
-		<!--Metatext-->
-		<meta name="Portfolio" />
-		<!--SEO Keywords-->
-		<meta name="keywords"
-			content="portfolio, coding-boot-camp, technical-writing, documentation, programming, engineering, slate" />
-		<!--Author-->
-		<meta name="author" content="Melissa Kinsey" />
-		<!--Viewport Dimensions-->
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!--Bootstrap Link-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
-		<!-- Google Fonts Link -->
-		<link href="https://fonts.googleapis.com/css2?family=Red+Rose:wght@300;400;500;600;700&display=swap"
-			rel="stylesheet" />
-		<!--CSS Link-->
-		<link rel="stylesheet" href="style.css" />
-	</head>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.js"
+      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      fetch("head-common.html")
+        .then((response) => response.text())
+        .then((data) => {
+          document.head.insertAdjacentHTML("beforeend", data);
+        });
+    </script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+  <body>
+    <!--NAV HEADER-->
+    <div id="header"></div>
+    <!--BEGIN CONTAINER-1-->
+    <div class="container-1">
+      <div class="jumbotron">
+        <div class="container text-center">
+          <img src="assets/name-5.png" width="70%" />
+          <p id="jumbotron">
+            I'm a versatile tech writer with experience in software development
+            and medical publishing. In addition to producing developer
+            documentation, I've written about medicine, technology, and death
+            for Slate.com, Healthline.com, Fast Company, DFW Airport,
+            Morningstar (the suits, not the veggie burgers), QSR Magazine, and
+            others.
+          </p>
+        </div>
+      </div>
+    </div>
+    <!--BEGIN CONTAINER-2-->
+    <div class="container-fluid bg-3 text-center">
+      <h1 class="special">Writing Portfolio</h1>
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            Doctors Tweeting Photos (Slate)
+            <br /><a
+              href="https://slate.com/technology/2014/01/doctors-on-social-media-share-embarrassing-photos-details-of-patients.html"
+            >
+              <img
+                src="assets/Doctor with scrip.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Doctor holding a prescription"
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Leave Meddling to the Hardy Boys (Slate)
+            <br /><a
+              href="https://slate.com/technology/2018/08/meddling-is-the-worst-word-to-use-to-describe-russias-election-interference.html"
+            >
+              <img
+                src="assets/Meddling.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Magnifying glass"
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Doctors' Germy Smartphones (Slate)
+            <br /><a
+              href="https://slate.com/technology/2019/01/health-care-workers-germs-smartphones-infections.html"
+            >
+              <img
+                src="assets/Germy phones.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Doctor in surgical gloves holding a smartphone"
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Online Death Marketplace (Slate)
+            <br /><a
+              href="https://slate.com/technology/2017/12/legacy-com-has-cornered-the-market-on-death-online.html"
+            >
+              <img
+                src="assets/Candle.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="A lit candle"
+              /><br />
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <br />
 
-	<body>
-		<!--NAV HEADER-->
-		<div id="header"></div>
-		<!--BEGIN CONTAINER-1-->
-		<div class="container-1">
-			<div class="jumbotron">
-				<div class="container text-center">
-					<img src="assets/name-5.png" width="70%" />
-					<p id="jumbotron">
-						I'm a versatile tech writer with experience in software
-						development and medical publishing. In addition to
-						producing developer documentation, I've written about
-						medicine, technology, and death for Slate.com,
-						Healthline.com, Fast Company, DFW Airport, Morningstar
-						(the suits, not the veggie burgers), QSR Magazine, and
-						others. 
-					</p>
-				</div>
-			</div>
-		</div>
-		<!--BEGIN CONTAINER-2-->
-		<div class="container-fluid bg-3 text-center">
-			<h1 class="special">Writing Portfolio</h1>
-			<div class="row">
-				<div class="col-sm-3">
-					<p>
-						Doctors Tweeting Photos (Slate)
-						<br><a
-							href="https://slate.com/technology/2014/01/doctors-on-social-media-share-embarrassing-photos-details-of-patients.html">
-							<img src="assets/Doctor with scrip.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Doctor holding a prescription" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Leave Meddling to the Hardy Boys (Slate)
-						<br><a
-							href="https://slate.com/technology/2018/08/meddling-is-the-worst-word-to-use-to-describe-russias-election-interference.html">
-							<img src="assets/Meddling.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Magnifying glass" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Doctors' Germy Smartphones (Slate)
-						<br><a
-							href="https://slate.com/technology/2019/01/health-care-workers-germs-smartphones-infections.html">
-							<img src="assets/Germy phones.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Doctor in surgical gloves holding a smartphone" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Online Death Marketplace (Slate)
-						<br><a
-							href="https://slate.com/technology/2017/12/legacy-com-has-cornered-the-market-on-death-online.html">
-							<img src="assets/Candle.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="A lit candle" /><br>
-						</a>
-					</p>
-				</div>
-			</div>
-		</div>
-		<br />
+    <!--BEGIN CONTAINER-4-->
+    <div class="container-fluid bg-3 text-center">
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            Implanted Medical Devices (Slate)
+            <br /><a
+              href="https://slate.com/technology/2017/10/implanted-medical-devices-are-saving-lives-theyre-also-causing-exploding-corpses.html"
+            >
+              <img
+                src="assets/Crematorium.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt=""
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Absurdity of Smartphone Addiction (Slate)
+            <br /><a
+              href="https://slate.com/technology/2015/08/smartphone-addiction-is-not-a-real-diagnosis.html"
+            >
+              <img
+                src="assets/Smartphone addiction.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Woman holding smartphone"
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Facetime Farewells (Slate)
+            <br /><a
+              href="https://slate.com/technology/2014/10/facetime-skype-farewells-how-video-calling-changes-the-way-we-say-our-last-goodbyes.html"
+            >
+              <img
+                src="assets/Capt. Martin.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Vintage photo of a handsome young Air Force captain"
+              /><br />
+            </a>
+          </p>
+        </div>
+        <div class="col-sm-3">
+          <p>
+            Email Your Doctor (Slate)
+            <br /><a
+              href="https://slate.com/technology/2014/06/telemedicine-e-visits-doctors-should-start-using-email.html"
+            >
+              <img
+                src="assets/Doctor.jpg"
+                class="shadow img-responsive"
+                style="width: 100%"
+                alt="Doctor in a white coat"
+              /><br />
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-3">
+      <p>
+        Electronic Health Record (Elsevier)
+        <br /><a href="samples/sample-book-pages.pdf">
+          <img
+            src="assets/stethoscope.png"
+            class="shadow img-responsive"
+            style="width: 100%"
+            alt=""
+          /><br />
+        </a>
+      </p>
+      <legend>
+        Elsevier (Saunders) asked me to help write a first-edition textbook,
+        <i>The Electronic Health Record for the Physician's Office</i>, for
+        which I was credited as co-author.
+      </legend>
+    </div>
+    <div class="col-sm-3">
+      <p>
+        Life Partners (Blue Waters Group)
+        <br /><a href="samples/partners-for-life.pdf">
+          <img
+            src="assets/microscope.png"
+            class="shadow img-responsive"
+            style="width: 100%"
+            alt="Microscope icon, courtesy AdrianoKF/Pixabay"
+          /><br />
+        </a>
+      </p>
+      <legend>
+        Biomicrofluidics technology was new when I wrote this piece a few years
+        ago on behalf of The Blue Waters Group. The article profiles a Notre
+        Dame scientist who paired up with a biotech entrepreneur to develop a
+        handheld diagnostic tool.
+      </legend>
+    </div>
+    <div class="col-sm-3">
+      <p>
+        The Digestive System (Healthline.com)
+        <br /><a href="samples/digestive-system.pdf">
+          <img
+            src="assets/digestive-system.png"
+            class="shadow img-responsive"
+            style="width: 100%"
+            alt="Digestive system icon, courtesy mcmurryjulie/Pixabay"
+          />
+        </a>
+      </p>
+      <legend>
+        When Healthline.com was just getting off the ground, the editors asked
+        me to write a series of "Learning Center" articles on various body
+        systems. This is one of my favorites.
+      </legend>
+    </div>
+    <div class="col-sm-3">
+      <p>
+        How the Eye Works (Lighthouse)
+        <br /><a href="samples/how-the-eye-works.pdf">
+          <img
+            src="assets/glasses.png"
+            class="shadow img-responsive"
+            style="width: 100%"
+            alt="Eyeglasses. Adapted from a photo by Morris Huberland (1909–1974), courtesy of the New York Public Library."
+          />
+          <br />
+        </a>
+      </p>
+      <legend>
+        This piece is from a series of articles I wrote for Lighthouse
+        International, a charitable organization that supports people with
+        blindness or low vision.
+      </legend>
+    </div>
 
-		<!--BEGIN CONTAINER-4-->
-		<div class="container-fluid bg-3 text-center">
-			<div class="row">
-				<div class="col-sm-3">
-					<p>
-						Implanted Medical Devices (Slate)
-						<br><a
-							href="https://slate.com/technology/2017/10/implanted-medical-devices-are-saving-lives-theyre-also-causing-exploding-corpses.html">
-							<img src="assets/Crematorium.jpg" class="shadow img-responsive" style="width: 100%" alt="" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Absurdity of Smartphone Addiction (Slate)
-						<br><a
-							href="https://slate.com/technology/2015/08/smartphone-addiction-is-not-a-real-diagnosis.html">
-							<img src="assets/Smartphone addiction.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Woman holding smartphone" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Facetime Farewells (Slate)
-						<br><a
-							href="https://slate.com/technology/2014/10/facetime-skype-farewells-how-video-calling-changes-the-way-we-say-our-last-goodbyes.html">
-							<img src="assets/Capt. Martin.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Vintage photo of a handsome young Air Force captain" /><br>
-						</a>
-					</p>
-				</div>
-				<div class="col-sm-3">
-					<p>
-						Email Your Doctor (Slate)
-						<br><a
-							href="https://slate.com/technology/2014/06/telemedicine-e-visits-doctors-should-start-using-email.html">
-							<img src="assets/Doctor.jpg" class="shadow img-responsive" style="width: 100%"
-								alt="Doctor in a white coat" /><br>
-						</a>
-					</p>
-				</div>
-			</div>
-		</div>
-		<div class="col-sm-3">
-			<p>
-				Electronic Health Record
-				(Elsevier)
-				<br><a href="samples/sample-book-pages.pdf">
-					<img src="assets/stethoscope.png" class="shadow img-responsive" style="width: 100%" alt="" /><br>
-				</a>
-			</p>
-			<legend>
-				Elsevier (Saunders) asked me to help write a first-edition textbook, <i>The Electronic Health Record for the Physician's Office</i>, for which I was credited as co-author.
-			</legend>
-		</div>
-		<div class="col-sm-3">
-			<p>
-				Life Partners (Blue Waters Group)
-				<br><a href="samples/partners-for-life.pdf">
-					<img src="assets/microscope.png" class="shadow img-responsive" style="width: 100%"
-						alt="Microscope icon, courtesy AdrianoKF/Pixabay" /><br>
-				</a>
-			</p>
-			<legend>
-				Biomicrofluidics technology was new when I wrote this piece a
-				few years ago on behalf of The Blue Waters Group. The article
-				profiles a Notre Dame scientist who paired up with a biotech
-				entrepreneur to develop a handheld diagnostic tool.
-			</legend>
-		</div>
-		<div class="col-sm-3">
-			<p>
-				The Digestive System (Healthline.com)
-						<br><a href="samples/digestive-system.pdf">
-					<img src="assets/digestive-system.png" class="shadow img-responsive" style="width: 100%"
-						alt="Digestive system icon, courtesy mcmurryjulie/Pixabay" />
-				</a>
-			</p>
-			<legend>
-				When Healthline.com was just getting off the ground, the editors
-				asked me to write a series of "Learning Center" articles on
-				various body systems. This is one of my favorites.
-			</legend>
-		</div>
-		<div class="col-sm-3">
-			<p>
-				How the Eye Works (Lighthouse)
-			<br><a href="samples/how-the-eye-works.pdf">
-					<img src="assets/glasses.png" class="shadow img-responsive" style="width: 100%"
-						alt="Eyeglasses. Adapted from a photo by Morris Huberland (1909–1974), courtesy of the New York Public Library." />
-						<br>
-				</a>
-			</p>
-			<legend>
-				This piece is from a series of articles I wrote for Lighthouse
-				International, a charitable organization that supports people
-				with blindness or low vision.
-			</legend>
-		</div>
-
-		<!--BEGIN FOOTER-->
-		<div id="footer"></div>
-	</body>
-
+    <!--BEGIN FOOTER-->
+    <div id="footer"></div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary of changes
- Moved shared head markup into `head-common.html`
- Updated portfolio pages to load the shared head content
- Added `.gitignore`

## Rationale
- Reduces duplicated head markup across pages
- Makes future metadata and asset updates easier to maintain
- Keeps shared changes consistent across the portfolio site

## Files updated
- `index.html`
- `contact.html`
- `infographics.html`
- `logos.html`
- `writing-samples.html`
- `github.html`
- `head-common.html`
- `.gitignore`